### PR TITLE
feat: Implement modular Flask application structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
-# aether
+# Modular Flask Application for ArtNet
+
+This project provides a modular Flask application structure designed for ArtNet integration. It uses blueprints to organize routes and functionality, making it easy to extend and maintain.
+
+## Project Structure
+
+```
+/
+├── app/                    # Main application package
+│   ├── __init__.py         # Application factory (create_app)
+│   ├── modules/            # Directory for application modules (blueprints)
+│   │   └── core/           # Example 'core' module for ArtNet
+│   │       ├── __init__.py # Makes 'core' a Python package
+│   │       └── routes.py   # Defines routes for the 'core' module
+│   ├── static/             # Static files (CSS, JavaScript, images)
+│   └── templates/          # HTML templates
+├── run.py                  # Script to run the Flask development server
+└── README.md               # This file
+```
+
+## Running the Application
+
+1.  **Ensure Python and Flask are installed.**
+    If not, install Flask:
+    ```bash
+    pip install Flask
+    ```
+2.  **Navigate to the project root directory.**
+3.  **Run the application:**
+    ```bash
+    python run.py
+    ```
+    The application will start in debug mode, typically on `http://127.0.0.1:5000/`. The ArtNet routes will be available under the `/artnet` prefix (e.g., `http://127.0.0.1:5000/artnet/universes`).
+
+## Adding New Modules (Blueprints)
+
+To add a new module (e.g., a 'lighting_effects' module):
+
+1.  **Create a new module directory:**
+    Inside `app/modules/`, create a new directory for your module (e.g., `app/modules/lighting_effects/`).
+2.  **Initialize the module package:**
+    Create an empty `__init__.py` file within your new module directory (e.g., `app/modules/lighting_effects/__init__.py`).
+3.  **Define routes in `routes.py`:**
+    Create a `routes.py` file in your module directory (e.g., `app/modules/lighting_effects/routes.py`). Define your blueprint and routes here:
+
+    ```python
+    # app/modules/lighting_effects/routes.py
+    from flask import Blueprint, jsonify
+
+    lighting_bp = Blueprint('lighting_bp', __name__, url_prefix='/lighting')
+
+    @lighting_bp.route('/strobe')
+    def strobe_effect():
+        return jsonify({"effect": "strobe activated"})
+
+    # Add other lighting effect routes here...
+    ```
+4.  **Register the new blueprint:**
+    In `app/__init__.py`, import and register your new blueprint within the `create_app` function:
+
+    ```python
+    # app/__init__.py
+    from flask import Flask
+
+    def create_app():
+        app = Flask(__name__)
+
+        # ... (other configurations)
+
+        # Import and register core blueprint
+        from app.modules.core.routes import core_bp
+        app.register_blueprint(core_bp, url_prefix='/artnet')
+
+        # Import and register your new blueprint
+        from app.modules.lighting_effects.routes import lighting_bp # Adjust import path
+        app.register_blueprint(lighting_bp) # url_prefix is already in blueprint definition
+
+        return app
+    ```
+
+This structure allows for clean separation of concerns and makes it straightforward for other developers to contribute new functionalities by adding their own modules.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,12 @@
+from flask import Flask
+
+def create_app():
+    app = Flask(__name__)
+
+    # Configuration can be added here, e.g., app.config.from_object('config.Config')
+
+    # Import and register blueprints
+    from app.modules.core.routes import core_bp
+    app.register_blueprint(core_bp, url_prefix='/artnet') # Example prefix, can be changed
+
+    return app

--- a/app/modules/core/routes.py
+++ b/app/modules/core/routes.py
@@ -1,0 +1,13 @@
+from flask import Blueprint, jsonify
+
+core_bp = Blueprint('core_bp', __name__)
+
+@core_bp.route('/universes')
+def get_universes():
+    # Placeholder for ArtNet universe data
+    return jsonify({"message": "List of ArtNet universes"})
+
+@core_bp.route('/nodes')
+def get_nodes():
+    # Placeholder for ArtNet node data
+    return jsonify({"message": "List of ArtNet nodes"})

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
This commit introduces a modular Flask application structure using blueprints.

Key changes:
- Initializes a Flask app in `app/__init__.py` using the application factory pattern (`create_app`).
- Sets up a `core` blueprint in `app/modules/core/routes.py` for ArtNet-related routes (e.g., `/artnet/universes`, `/artnet/nodes`).
- Includes `app/static` and `app/templates` directories.
- Provides a `run.py` script to start the development server.
- Updates `README.md` with details on the structure, how to run the application, and a guide for other developers to add new modules via blueprints.

This structure is designed to be easily extensible for future ArtNet integration and other functionalities.