### PR TITLE
feat: Implement fixture upload and display functionality

### DIFF
--- a/app/modules/patch/routes.py
+++ b/app/modules/patch/routes.py
@@ -1,4 +1,8 @@
-from flask import Blueprint, jsonify, render_template
+import os
+import glob
+import json
+from flask import Blueprint, jsonify, render_template, request, current_app
+from werkzeug.utils import secure_filename
 from app.classes import Helper
 
 patch_bp = Blueprint('patch_bp', __name__, template_folder='../../templates/patch')
@@ -12,3 +16,76 @@ def patch_index():
 def get_nodes():
     nodes = Helper.discover_artnet_nodes(ip_address='192.168.1.100', timeout=2.0)
     return jsonify(nodes)
+
+@patch_bp.route('/api/fixtures/upload', methods=['POST'])
+def upload_fixture_file():
+    if 'file' not in request.files:
+        return jsonify({'error': 'No file part in the request'}), 400
+    
+    file = request.files['file']
+    
+    if file.filename == '':
+        return jsonify({'error': 'No selected file'}), 400
+    
+    if file and file.filename.endswith('.json'):
+        filename = secure_filename(file.filename)
+        # Construct the path relative to the 'app' directory
+        # current_app.root_path is <project_root>/app
+        upload_folder = os.path.join(current_app.root_path, 'fixture_definitions')
+        
+        # Create the directory if it doesn't exist
+        os.makedirs(upload_folder, exist_ok=True)
+        
+        file_path = os.path.join(upload_folder, filename)
+        
+        try:
+            file.save(file_path)
+            return jsonify({'message': f'File "{filename}" uploaded successfully'})
+        except Exception as e:
+            return jsonify({'error': f'Error saving file: {str(e)}'}), 500
+    else:
+        return jsonify({'error': 'Invalid file type, only .json files are allowed'}), 400
+
+@patch_bp.route('/api/fixtures', methods=['GET'])
+def list_fixtures():
+    # Construct the path relative to the 'app' directory
+    # current_app.root_path is <project_root>/app
+    fixtures_folder = os.path.join(current_app.root_path, 'fixture_definitions')
+    
+    if not os.path.isdir(fixtures_folder):
+        # If the folder doesn't exist, return an empty list.
+        # This is not an error, just means no fixtures have been uploaded yet.
+        return jsonify([]) 
+        
+    fixture_files = glob.glob(os.path.join(fixtures_folder, '*.json'))
+    
+    fixtures_data = []
+    for file_path in fixture_files:
+        try:
+            with open(file_path, 'r') as f:
+                data = json.load(f)
+                
+            # Extract fixture name (top-level "name" key)
+            fixture_name = data.get('name', 'Unknown Fixture')
+            
+            # Extract channel count from the first mode
+            channel_count = 0 # Default if modes are not found or structured as expected
+            modes = data.get('modes')
+            if modes and isinstance(modes, list) and len(modes) > 0:
+                first_mode = modes[0]
+                if isinstance(first_mode, dict) and 'channels' in first_mode and isinstance(first_mode['channels'], list):
+                    channel_count = len(first_mode['channels'])
+            
+            fixtures_data.append({
+                'fixture_name': fixture_name,
+                'channel_count': channel_count,
+                # Optionally, include the filename if useful for debugging or frontend keying
+                'filename': os.path.basename(file_path) 
+            })
+        except json.JSONDecodeError:
+            # Log this error or handle as appropriate
+            print(f"Error decoding JSON from file: {file_path}") 
+        except Exception as e:
+            print(f"Error processing file {file_path}: {str(e)}")
+            
+    return jsonify(fixtures_data)

--- a/app/templates/patch/patch.html
+++ b/app/templates/patch/patch.html
@@ -321,6 +321,7 @@ remove
 <section class="col-span-4 card">
 <div class="flex justify-between items-center mb-4">
         <h2 class="text-lg font-medium">Fixures</h2>
+        <button class="p-1 rounded-full hover:bg-gray-700" id="fixture_add"> <span class="material-symbols-outlined">add</span> </button>
         <div class="flex items-center space-x-2">
           <button class="p-1 rounded-full hover:bg-gray-700">
             <span class="material-symbols-outlined">
@@ -329,6 +330,7 @@ more_horiz
           </button>
         </div>
       </div>
+      <input type="file" id="fixture_file_input" style="display: none;" accept=".json">
 <div class="grid grid-cols-3 gap-4" id="fixtures_panel">
 <div class="list-item-container selectable flex flex-col items-center text-center">
 <img alt="Light fixture icon" class="list-item-icon mb-1" src="{{ url_for('static', filename='assets/icon_mh.png') }}" width="160" height="200">


### PR DESCRIPTION
This commit introduces features for managing lighting fixtures:

1.  **Fixture Upload:**
    - You can click an "Add Fixture" button in `patch.html`.
    - This opens a file dialog, allowing selection of JSON files.
    - Selected files are POSTed to a new endpoint `/api/fixtures/upload`.
    - The backend saves these files to `app/fixture_definitions/` (creating the directory if it doesn't exist).

2.  **Fixture Display:**
    - On page load, fixture data is fetched from a new endpoint `/api/fixtures`.
    - This endpoint reads all `.json` files from `app/fixture_definitions/`.
    - It parses each file, extracting the fixture name (from the "name" key) and channel count (from the first mode in the "modes" array, compatible with Open Fixture Library format).
    - Fixtures are rendered as list items in the `fixtures_panel` on `patch.html`.
    - The fixture list automatically refreshes after a new fixture is uploaded.

Modifications include changes to:
- `app/templates/patch/patch.html`: Added UI elements for upload.
- `app/static/js/patch.js`: Implemented client-side logic for upload and display.
- `app/modules/patch/routes.py`: Added new API endpoints for file upload and listing fixtures.